### PR TITLE
Bug Fixes

### DIFF
--- a/pmmenu/mainscene.py
+++ b/pmmenu/mainscene.py
@@ -231,6 +231,8 @@ class MainScene(object):
 					self.do_menu_item_action(sprite)
 					
 			action = None	
+			if self.warning and not self.warning.menu_open: self.warning = None
+			
 			if event.type == pygame.KEYDOWN: 
 				action = self.CONTROLS.get_action('keyboard', event.key)
 				pressed = pygame.key.get_pressed()
@@ -273,7 +275,7 @@ class MainScene(object):
 			elif self.popup.menu_open:
 				self.popup.handle_events(action, self.screen, self.effect)
 			else:
-			
+				
 				if action == 'LEFT':
 					self.set_selected_index(self.selected_index - 1)
 					

--- a/pmmenu/romlistscene.py
+++ b/pmmenu/romlistscene.py
@@ -128,7 +128,7 @@ class RomListScene(object):
 					self.popup.menu_open = False
 					self.screen.blit(self.cfg.options.fade_image, (0,0))
 					
-					self.clear_rom_item()
+					self.clear_rom_item(False)
 					found_index = self.popup.menu_work.abc_find(self.list.rom_list)
 					self.list.set_visible_items(found_index, found_index + self.items_per_screen)
 					self.draw_list(self.cfg.options.rom_list_orientation)


### PR DESCRIPTION
Fixed warning bug - when user pressed escape from "rom files have
changed" they could no longer make any selections.

Fixed letter skip romlist bug - when user chose letter 'Z', the romlist
didn't erase existing entries
