### PR TITLE
.8b8 - fixed 'hide clones' option in romlistscene

### DIFF
--- a/pmmenu/menuitem.py
+++ b/pmmenu/menuitem.py
@@ -173,7 +173,7 @@ class PMMenuItem(pygame.sprite.Sprite):
 		if self.cfg.options.rom_filter.lower() != 'all' : query += ' AND genres LIKE "%{genre_filter}%"'.format(genre_filter = self.cfg.options.rom_filter)
 		
 		#exclude clones
-		if not self.cfg.options.show_clones: query += ' AND cloneof is NULL'
+		if not self.cfg.options.show_clones: query += ' AND cloneof = ""'
 		
 		#hide unmatched roms
 		if not self.cfg.options.show_unmatched_roms: query += ' AND (flags is null or flags not like "%no_match%")'

--- a/pmmenu/pmlist.py
+++ b/pmmenu/pmlist.py
@@ -51,7 +51,7 @@ class PMList(pygame.sprite.OrderedUpdates):
 		if self.cfg.options.rom_filter.lower() != 'all' : query += ' AND genres LIKE "%{genre_filter}%"'.format(genre_filter = self.cfg.options.rom_filter)
 		
 		#exclude clones
-		if not self.cfg.options.show_clones: query += ' AND cloneof is NULL'
+		if not self.cfg.options.show_clones: query += ' AND cloneof = ""'
 		
 		#hide unmatched roms
 		if not self.cfg.options.show_unmatched_roms: query += ' AND (flags is null or flags not like "%no_match%")'

--- a/scraper/scrape_script.py
+++ b/scraper/scrape_script.py
@@ -619,6 +619,7 @@ class API(object):
 							game_info= Game(title = temp_game_info['title'],
 													system = platform['id'],
 													parent = temp_game_info['parent'],
+													cloneof = temp_game_info['cloneof'],
 													search_terms = temp_game_info['search_terms'],
 													release_date = temp_game_info['release_date'],
 													overview = temp_game_info['overview'],


### PR DESCRIPTION
'hide clones' wasn't actually doing anything. First, the scraper wasn't
adding the 'cloneof' attribute, then sql query was malformed and didn't
filter out clones.
